### PR TITLE
bug/7 Fix the stack overflow problem when using regex to match string literals

### DIFF
--- a/src/main/java/tw/waterball/judgegirl/cqi/cyclomatic/CyclomaticComplexityCalculatorImpl.java
+++ b/src/main/java/tw/waterball/judgegirl/cqi/cyclomatic/CyclomaticComplexityCalculatorImpl.java
@@ -84,12 +84,12 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
     }
 
     private String removeStringLiterals(String sourceCode) {
-        String result = new String("");
+        StringBuilder result = new StringBuilder();
         Boolean inStr = false;
         for(int i = 0; i < sourceCode.length(); i++) {
             if(inStr) {
                 if(sourceCode.charAt(i) == '"') {
-                    result += '"';
+                    result.append('"');
                     inStr = false;
                 }
                 else if(sourceCode.charAt(i) == '\\') {
@@ -97,13 +97,13 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
                 }
             }
             else {
-                result += sourceCode.charAt(i);
+                result.append(sourceCode.charAt(i));
                 if(sourceCode.charAt(i) == '"') {
                     inStr = true;
                 }
             }
         }
-        return result;
+        return result.toString();
     }
 
     private int calculateCCScore(String sourceCode) {

--- a/src/main/java/tw/waterball/judgegirl/cqi/cyclomatic/CyclomaticComplexityCalculatorImpl.java
+++ b/src/main/java/tw/waterball/judgegirl/cqi/cyclomatic/CyclomaticComplexityCalculatorImpl.java
@@ -40,7 +40,7 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
 
     private int calculateSingleCode(String sourceCode) {
         sourceCode = preprocess(sourceCode);
-        return calculateCCScore(sourceCode) - calculateCCInStringLiterals(sourceCode);
+        return calculateCCScore(sourceCode);
     }
 
     private String preprocess(String sourceCode) {
@@ -49,6 +49,7 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
         sourceCode = callCPreprocessor(sourceCode);
         sourceCode = removePattern(sourceCode, "\n# [0-9]+ [^\n]*");
         sourceCode = removePattern(sourceCode, "^[ \t\n]*");
+        sourceCode = removeStringLiterals(sourceCode);
         return sourceCode;
     }
 
@@ -82,6 +83,29 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
         return sourceCode;
     }
 
+    private String removeStringLiterals(String sourceCode) {
+        String result = new String("");
+        Boolean inStr = false;
+        for(int i = 0; i < sourceCode.length(); i++) {
+            if(inStr) {
+                if(sourceCode.charAt(i) == '"') {
+                    result += '"';
+                    inStr = false;
+                }
+                else if(sourceCode.charAt(i) == '\\') {
+                    i++;
+                }
+            }
+            else {
+                result += sourceCode.charAt(i);
+                if(sourceCode.charAt(i) == '"') {
+                    inStr = true;
+                }
+            }
+        }
+        return result;
+    }
+
     private int calculateCCScore(String sourceCode) {
         String patternString = "([^0-9A-Za-z_]((if)|(case)|(for)|(while)|(catch))[^0-9A-Za-z_])|[&][&]|[|][|]|[?]";
         Pattern pattern = Pattern.compile(patternString);
@@ -89,17 +113,6 @@ public class CyclomaticComplexityCalculatorImpl implements CyclomaticComplexityC
         int counter = 0;
         while(matcher.find()) {
             counter++;
-        }
-        return counter;
-    }
-
-    private int calculateCCInStringLiterals(String code) {
-        String patternString = "\"(\\.|[^\"\n])*\"";
-        Pattern pattern = Pattern.compile(patternString);
-        Matcher matcher = pattern.matcher(code);
-        int counter = 0;
-        while(matcher.find()) {
-            counter += calculateCCScore(matcher.group());
         }
         return counter;
     }


### PR DESCRIPTION
Instead of using regex to match string literal which will cause stack overflow when encountering a long string literal, I use for loop to remove the content of each string literals before calculating CC score to solve the problem.